### PR TITLE
Support Prism highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,29 @@ favicon: foobar.png
 ```
 
 ### Code Highlight
-This code highlighting is implemented using [highlight.js](https://highlightjs.org/), If you want to turn on code highlighting, please add the `highlight` in `_config.yml` of your Hexo:
+#### Highlight
+Add the `highlight` in `_config.yml` of your Hexo:
 
 ```yaml
 highlight:
   enable: true
   hljs: true
+```
+
+#### Prism
+See [Hexo document](https://hexo.io/docs/syntax-highlight#PrismJS) for details.
+
+Add the `prismjs` in `_config.yml` of your Hexo:
+
+```yaml
+highlight:
+  enable: false
+prismjs:
+  enable: true
+  preprocess: true
+  line_number: true
+  line_threshold: 0
+  # tab_replace: '    '
 ```
 
 ### Podcast

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -50,6 +50,21 @@
     <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <% } %>
+    <% if (config.prismjs.enable) { %>
+    <link href="//cdn.jsdelivr.net/npm/prismjs@1.27.0/themes/prism.min.css" rel="stylesheet" />
+
+        <% if (config.prismjs.line_number) { %>
+        <link href="//cdn.jsdelivr.net/npm/prismjs@1.27.0/plugins/line-numbers/prism-line-numbers.min.css" rel="stylesheet" />
+        <% } %>
+
+        <% if (!config.prismjs.preprocess) { %>
+        <script src="//cdn.jsdelivr.net/npm/prismjs@1.27.0/components/prism-core.min.js"></script>
+        <script src="//cdn.jsdelivr.net/npm/prismjs@1.27.0/plugins/autoloader/prism-autoloader.min.js"></script>
+            <% if (config.prismjs.line_number) { %>
+            <script src="//cdn.jsdelivr.net/npm/prismjs@1.27.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+            <% } %>
+        <% } %>
+    <% } %>
     <% if (theme.podcast) { %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/shikwasa@2.0.0/dist/shikwasa.min.css">
     <script src="https://cdn.jsdelivr.net/npm/shikwasa@2.0.0/dist/shikwasa.min.js"></script>

--- a/source/css/_partial/dark.styl
+++ b/source/css/_partial/dark.styl
@@ -31,7 +31,8 @@ body {
 
 .post {
     border-color: #616161;
-    code, pre {
+    /* `.token.punctuation` is a keyword of Prism */
+    code, pre, .token.punctuation {
         background-color: black;
         color: white;
     }
@@ -40,6 +41,14 @@ body {
     }
     a {
         color: #e5e5e5;
+    }
+    /* Remove `text-shadow` from Prism */
+    code[class*=language-], pre[class*=language-] {
+        text-shadow: 0 0 black;
+    }
+    /* Remove `background` from Prism */
+    .language-css .token.string, .style .token.string, .token.entity, .token.operator, .token.url {
+        background: unset;
     }
 }
 


### PR DESCRIPTION
As [highlight.js doesn't support line number](https://highlightjs.readthedocs.io/en/latest/line-numbers.html) nativly. I made a support for the [Prism.js](https://prismjs.com/).